### PR TITLE
Add single page React website

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,36 @@
+const { useState, useEffect } = React;
+
+function App() {
+  const [showMap, setShowMap] = useState(false);
+
+  useEffect(() => {
+    const btn = document.getElementById('contact-btn');
+    let pos = 0;
+    let direction = 1;
+    const interval = setInterval(() => {
+      pos += direction;
+      if (pos > 20 || pos < -20) direction *= -1;
+      btn.style.transform = `translateX(${pos}px)`;
+    }, 50);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="container">
+      <header>
+        <h1>Koya AI Integrations</h1>
+        <p>Transforming business with design and automation.</p>
+      </header>
+      <button id="contact-btn" onClick={() => setShowMap(!showMap)}>
+        Contact Me
+      </button>
+      {showMap && (
+        <div className="map-overlay" onClick={() => setShowMap(false)}>
+          <img src="public/map.svg" alt="Map of Gelsenkirchen Buer" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Koya AI Integration</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=SF+Pro+Display:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" src="App.js"></script>
+</body>
+</html>

--- a/public/map.svg
+++ b/public/map.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#f0f0f0"/>
+  <g stroke="#000" stroke-width="1" fill="none">
+    <path d="M50 50 L550 50 L550 350 L50 350 Z"/>
+    <path d="M100 100 L500 100 M100 150 L500 150 M100 200 L500 200 M100 250 L500 250" stroke-dasharray="5,5"/>
+    <path d="M200 50 L200 350 M300 50 L300 350 M400 50 L400 350" stroke-dasharray="5,5"/>
+    <path d="M50 300 C100 270, 150 330, 200 300 S300 270, 350 300 S450 330, 550 300"/>
+  </g>
+  <text x="300" y="380" font-size="24" text-anchor="middle" fill="#888">Gelsenkirchen Buer</text>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,59 @@
+body {
+  margin: 0;
+  font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background-color: #1B1F3B;
+  color: white;
+  text-align: center;
+  overflow-x: hidden;
+}
+
+.container {
+  padding: 50px 20px;
+}
+
+header h1 {
+  font-size: 3rem;
+  margin: 0;
+  letter-spacing: 1px;
+}
+
+header p {
+  font-size: 1.2rem;
+  color: #d0d0d0;
+}
+
+#contact-btn {
+  margin-top: 40px;
+  padding: 15px 30px;
+  font-size: 1rem;
+  border: none;
+  background-color: #fff;
+  color: #1B1F3B;
+  border-radius: 30px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  position: relative;
+}
+
+#contact-btn:hover {
+  transform: scale(1.05);
+}
+
+.map-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(27,31,59,0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.map-overlay img {
+  max-width: 90%;
+  max-height: 90%;
+  filter: grayscale(100%) contrast(120%) brightness(90%);
+  box-shadow: 0 0 20px rgba(0,0,0,0.5);
+}


### PR DESCRIPTION
## Summary
- add a simple single-page React site served from `index.html`
- style using Apple-inspired typography and dark #1B1F3B palette
- move the contact button back and forth with React `useEffect`
- display a sketch-style map overlay when contact button is clicked

## Testing
- `git status --short`

------
